### PR TITLE
Add from_encoded

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,21 @@ pub fn from_env() -> RustFlags {
     }
 }
 
+/// Parse flags from a string separated with ASCII unit separator ('\x1f').
+///
+/// This is a valid format for the following environment variables:
+///
+/// - `CARGO_ENCODED_RUSTFLAGS` (Cargo 1.55+)
+/// - `CARGO_ENCODED_RUSTDOCFLAGS` (Cargo 1.55+)
+pub fn from_encoded(encoded: &str) -> RustFlags {
+    RustFlags {
+        encoded: encoded.to_owned(),
+        pos: 0,
+        repeat: None,
+        short: false,
+    }
+}
+
 /// **Iterator of rustc flags**
 pub struct RustFlags {
     encoded: String,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -7,12 +7,7 @@ use std::path::PathBuf;
 
 #[track_caller]
 fn test(encoded: &str, expected: &[Flag]) {
-    let mut iterator = RustFlags {
-        encoded: encoded.to_owned(),
-        pos: 0,
-        repeat: None,
-        short: false,
-    };
+    let mut iterator = crate::from_encoded(encoded);
 
     let mut flags = Vec::new();
     for expected in expected {


### PR DESCRIPTION
Ref: https://github.com/dtolnay/rustflags/issues/2

This PR simply adds a new construct fn to accept arbitrary flag strings.

For example, now it is possible to use with [cargo_config2](https://docs.rs/cargo-config2), like:

```rust
let config = cargo_config2::Config::load()?;
let target = "x86_64-unknown-linux-gnu";
let flags = config.rustflags(target)?.unwrap_or_default();
let parsed_flags = rustflags::from_encoded(flags.encode()?);
for flag in parsed_flags {
    ...
}
```