### PR TITLE
Skip rest of word after unrecognized short flag

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -346,7 +346,16 @@ pub(crate) fn parse(f: &mut RustFlags) -> Option<Flag> {
                 FlagConstructor::Flag(flag) => return Some(flag),
                 FlagConstructor::Opt(f) => ConstructorFn::Opt(f),
                 FlagConstructor::Repeated(f) => ConstructorFn::Repeated(f),
-                FlagConstructor::Unrecognized => continue,
+                FlagConstructor::Unrecognized => {
+                    // Skip rest of word.
+                    if let Some(i) = f.encoded[f.pos..].find(SEPARATOR) {
+                        f.pos += i + 1;
+                    } else {
+                        f.pos = f.encoded.len();
+                    }
+                    f.short = false;
+                    continue;
+                }
             };
             f.short = false;
             if f.pos == f.encoded.len() {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -327,7 +327,6 @@ fn test_unrecognized() {
             opt: "debuginfo".to_owned(),
             value: Some("2".to_owned()),
         },
-        Flag::Verbose,
-        Flag::Out(PathBuf::from("-h")),
+        Flag::Help,
     );
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -309,3 +309,25 @@ fn test_individual() {
         },
     );
 }
+
+#[test]
+fn test_unrecognized() {
+    assert_flags!(
+        "-goto",
+        Flag::Codegen {
+            opt: "debuginfo".to_owned(),
+            value: Some("2".to_owned()),
+        },
+        Flag::Out(PathBuf::from("to")),
+    );
+
+    assert_flags!(
+        "-gxvto" "-h",
+        Flag::Codegen {
+            opt: "debuginfo".to_owned(),
+            value: Some("2".to_owned()),
+        },
+        Flag::Verbose,
+        Flag::Out(PathBuf::from("-h")),
+    );
+}


### PR DESCRIPTION
For a flag like `-xv` where the 'x' is an unrecognized short flag, it isn't correct to skip 'x' and treat the 'v' as `-v`, because we don't know whether `-x` is supposed to take an argument, the way `-o` does. `-ov` does not mean `-o -v`. It means `-o v`, and `-x` might be like that too.