### PR TITLE
Raise required compiler to rust 1.74

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.57.0, 1.56.0]
+        rust: [nightly, beta, stable, 1.58.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,6 @@ jobs:
         if: matrix.rust == 'nightly'
       - run: cargo check
       - run: cargo test
-        if: matrix.rust != '1.56.0'
 
   doc:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.62.0]
+        rust: [nightly, beta, stable, 1.74.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        rust: [nightly, beta, stable, 1.58.0]
+        rust: [nightly, beta, stable, 1.62.0]
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/rustflags"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/rustflags"
-rust-version = "1.56"
+rust-version = "1.58"
 
 [dev-dependencies]
 cmake = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/rustflags"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/rustflags"
-rust-version = "1.62"
+rust-version = "1.74"
 
 [dev-dependencies]
 cmake = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/rustflags"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/dtolnay/rustflags"
-rust-version = "1.58"
+rust-version = "1.62"
 
 [dev-dependencies]
 cmake = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,7 @@
     clippy::needless_doctest_main,
     clippy::too_many_lines,
     clippy::type_complexity,
+    clippy::uninlined_format_args,
     clippy::unnecessary_wraps
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,7 +297,7 @@ pub enum Flag {
 }
 
 /// Argument of `-L`
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[non_exhaustive]
 pub enum LibraryKind {
     /// `dependency`
@@ -309,13 +309,8 @@ pub enum LibraryKind {
     /// `framework`
     Framework,
     /// `all` (the default)
+    #[default]
     All,
-}
-
-impl Default for LibraryKind {
-    fn default() -> Self {
-        LibraryKind::All
-    }
 }
 
 impl Display for LibraryKind {
@@ -331,7 +326,7 @@ impl Display for LibraryKind {
 }
 
 /// Argument of `-l`
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 #[non_exhaustive]
 pub enum LinkKind {
     /// `static`
@@ -339,13 +334,8 @@ pub enum LinkKind {
     /// `framework`
     Framework,
     /// `dylib` (the default)
+    #[default]
     Dylib,
-}
-
-impl Default for LinkKind {
-    fn default() -> Self {
-        LinkKind::Dylib
-    }
 }
 
 impl Display for LinkKind {
@@ -519,20 +509,15 @@ impl Display for ErrorFormat {
 }
 
 /// Argument of `--color`
-#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+#[derive(Default, Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum Color {
     /// Colorize, if output goes to a tty (default).
+    #[default]
     Auto,
     /// Always colorize output.
     Always,
     /// Never colorize output.
     Never,
-}
-
-impl Default for Color {
-    fn default() -> Self {
-        Color::Auto
-    }
 }
 
 impl Display for Color {


### PR DESCRIPTION
For use of `OsStr::as_encoded_bytes` in an upcoming commit.