### PR TITLE
Add a new type to represent encoded OS strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,12 @@
 
 mod parse;
 mod render;
+mod string;
 #[cfg(test)]
 mod tests;
 mod write;
 
+use crate::string::{EnvStr, EnvString};
 use std::env;
 use std::ffi::OsString;
 use std::fmt::{self, Display, Write};
@@ -90,7 +92,7 @@ pub fn from_env() -> RustFlags {
         .into_string()
         .unwrap_or_else(|s| s.to_string_lossy().into_owned());
     RustFlags {
-        encoded,
+        encoded: EnvString::new(encoded),
         pos: 0,
         repeat: None,
         short: false,
@@ -105,7 +107,7 @@ pub fn from_env() -> RustFlags {
 /// - `CARGO_ENCODED_RUSTDOCFLAGS` (Cargo 1.55+)
 pub fn from_encoded(encoded: &str) -> RustFlags {
     RustFlags {
-        encoded: encoded.to_owned(),
+        encoded: EnvString::new(encoded.to_owned()),
         pos: 0,
         repeat: None,
         short: false,
@@ -114,9 +116,9 @@ pub fn from_encoded(encoded: &str) -> RustFlags {
 
 /// **Iterator of rustc flags**
 pub struct RustFlags {
-    encoded: String,
+    encoded: EnvString,
     pos: usize,
-    repeat: Option<(fn(&str) -> Option<(Flag, usize)>, usize)>,
+    repeat: Option<(fn(&EnvStr) -> Option<(Flag, usize)>, usize)>,
     short: bool,
 }
 

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,0 +1,86 @@
+use std::ffi::OsStr;
+use std::ops::{Deref, Index, RangeBounds};
+use std::str::Chars;
+
+pub(crate) struct EnvString(String);
+
+#[repr(transparent)]
+pub(crate) struct EnvStr(str);
+
+impl EnvString {
+    pub fn new(encoded: String) -> Self {
+        EnvString(encoded)
+    }
+}
+
+impl Deref for EnvString {
+    type Target = EnvStr;
+
+    fn deref(&self) -> &Self::Target {
+        EnvStr::new(&self.0)
+    }
+}
+
+impl EnvStr {
+    fn new(encoded: &str) -> &Self {
+        unsafe { &*(encoded as *const str as *const EnvStr) }
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn find(&self, ch: char) -> Option<usize> {
+        self.0.find(ch)
+    }
+
+    pub fn starts_with(&self, ch: char) -> bool {
+        self.0.starts_with(ch)
+    }
+
+    pub fn ends_with(&self, ch: char) -> bool {
+        self.0.ends_with(ch)
+    }
+
+    pub fn chars(&self) -> Chars {
+        self.0.chars()
+    }
+
+    pub fn split_once(&self, ch: char) -> Option<(&EnvStr, &EnvStr)> {
+        let (first, rest) = self.0.split_once(ch)?;
+        Some((EnvStr::new(first), EnvStr::new(rest)))
+    }
+
+    pub fn to_str(&self) -> Option<&str> {
+        Some(&self.0)
+    }
+}
+
+impl<R> Index<R> for EnvStr
+where
+    R: RangeBounds<usize>,
+{
+    type Output = EnvStr;
+
+    fn index(&self, index: R) -> &Self::Output {
+        let start = index.start_bound().cloned();
+        let end = index.end_bound().cloned();
+        EnvStr::new(&self.0[(start, end)])
+    }
+}
+
+impl AsRef<OsStr> for EnvStr {
+    fn as_ref(&self) -> &OsStr {
+        self.0.as_ref()
+    }
+}
+
+impl Default for &EnvStr {
+    fn default() -> Self {
+        EnvStr::new("")
+    }
+}


### PR DESCRIPTION
Later we can swap this out with one backed by `OsString`, instead of `String`, to accommodate non-UTF8 filepaths in the arguments of flags like `--extern` and `--sysroot` and `-L` and `-o` and `--out-dir` and `--extern-location` and `--remap-path-prefix`.