### PR TITLE
Handle non-UTF8 filepaths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,16 +82,13 @@ mod write;
 
 use crate::string::{EnvStr, EnvString};
 use std::env;
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Write};
 use std::path::PathBuf;
 
 /// Parse flags from CARGO_ENCODED_RUSTFLAGS environment variable.
 pub fn from_env() -> RustFlags {
-    let encoded = env::var_os("CARGO_ENCODED_RUSTFLAGS")
-        .unwrap_or_default()
-        .into_string()
-        .unwrap_or_else(|s| s.to_string_lossy().into_owned());
+    let encoded = env::var_os("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
     RustFlags {
         encoded: EnvString::new(encoded),
         pos: 0,
@@ -106,7 +103,7 @@ pub fn from_env() -> RustFlags {
 ///
 /// - `CARGO_ENCODED_RUSTFLAGS` (Cargo 1.55+)
 /// - `CARGO_ENCODED_RUSTDOCFLAGS` (Cargo 1.55+)
-pub fn from_encoded(encoded: &str) -> RustFlags {
+pub fn from_encoded(encoded: &OsStr) -> RustFlags {
     RustFlags {
         encoded: EnvString::new(encoded.to_owned()),
         pos: 0,

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,14 +1,15 @@
-use std::ffi::OsStr;
-use std::ops::{Deref, Index, RangeBounds};
-use std::str::Chars;
+use std::cmp;
+use std::ffi::{OsStr, OsString};
+use std::ops::{Deref, Index, Range, RangeFrom, RangeTo};
+use std::str;
 
-pub(crate) struct EnvString(String);
+pub(crate) struct EnvString(OsString);
 
 #[repr(transparent)]
-pub(crate) struct EnvStr(str);
+pub(crate) struct EnvStr(OsStr);
 
 impl EnvString {
-    pub fn new(encoded: String) -> Self {
+    pub fn new(encoded: OsString) -> Self {
         EnvString(encoded)
     }
 }
@@ -22,8 +23,8 @@ impl Deref for EnvString {
 }
 
 impl EnvStr {
-    fn new(encoded: &str) -> &Self {
-        unsafe { &*(encoded as *const str as *const EnvStr) }
+    fn new(encoded: &OsStr) -> &Self {
+        unsafe { &*(encoded as *const OsStr as *const EnvStr) }
     }
 
     pub fn len(&self) -> usize {
@@ -35,52 +36,113 @@ impl EnvStr {
     }
 
     pub fn find(&self, ch: char) -> Option<usize> {
-        self.0.find(ch)
+        let mut buf = [0u8; 4];
+        let ch = ch.encode_utf8(&mut buf).as_bytes();
+        for i in 0..self.0.len() {
+            if self.0.as_encoded_bytes()[i..].starts_with(ch) {
+                return Some(i);
+            }
+        }
+        None
     }
 
     pub fn starts_with(&self, ch: char) -> bool {
-        self.0.starts_with(ch)
+        let mut buf = [0u8; 4];
+        let ch = ch.encode_utf8(&mut buf).as_bytes();
+        self.0.as_encoded_bytes().starts_with(ch)
     }
 
     pub fn ends_with(&self, ch: char) -> bool {
-        self.0.ends_with(ch)
+        let mut buf = [0u8; 4];
+        let ch = ch.encode_utf8(&mut buf).as_bytes();
+        self.0.as_encoded_bytes().ends_with(ch)
     }
 
-    pub fn chars(&self) -> Chars {
-        self.0.chars()
+    pub fn first_char(&self) -> Option<EnvChar> {
+        let encoded = self.0.as_encoded_bytes();
+        let prefix = cmp::min(encoded.len(), 4);
+        match str::from_utf8(&encoded[..prefix]) {
+            Ok(valid) => valid.chars().next().map(EnvChar::Valid),
+            Err(utf8_error) => {
+                let valid_up_to = utf8_error.valid_up_to();
+                if valid_up_to == 0 {
+                    Some(EnvChar::Invalid)
+                } else {
+                    let valid = str::from_utf8(&encoded[..valid_up_to]).unwrap();
+                    Some(EnvChar::Valid(valid.chars().next().unwrap()))
+                }
+            }
+        }
     }
 
     pub fn split_once(&self, ch: char) -> Option<(&EnvStr, &EnvStr)> {
-        let (first, rest) = self.0.split_once(ch)?;
-        Some((EnvStr::new(first), EnvStr::new(rest)))
+        let i = self.find(ch)?;
+        Some((&self[..i], &self[i + ch.len_utf8()..]))
     }
 
     pub fn to_str(&self) -> Option<&str> {
-        Some(&self.0)
+        self.0.to_str()
     }
 }
 
-impl<R> Index<R> for EnvStr
-where
-    R: RangeBounds<usize>,
-{
+impl Index<RangeFrom<usize>> for EnvStr {
     type Output = EnvStr;
 
-    fn index(&self, index: R) -> &Self::Output {
-        let start = index.start_bound().cloned();
-        let end = index.end_bound().cloned();
-        EnvStr::new(&self.0[(start, end)])
+    fn index(&self, range: RangeFrom<usize>) -> &Self::Output {
+        &self[range.start..self.len()]
+    }
+}
+
+impl Index<RangeTo<usize>> for EnvStr {
+    type Output = EnvStr;
+
+    fn index(&self, range: RangeTo<usize>) -> &Self::Output {
+        &self[0..range.end]
+    }
+}
+
+impl Index<Range<usize>> for EnvStr {
+    type Output = EnvStr;
+
+    fn index(&self, range: Range<usize>) -> &Self::Output {
+        fn is_utf8(slice: &[u8]) -> bool {
+            str::from_utf8(slice).is_ok()
+        }
+
+        let encoded = self.0.as_encoded_bytes();
+        for i in [range.start, range.end] {
+            assert!(
+                i == 0
+                    || i == encoded.len()
+                    || encoded.get(i..i.wrapping_add(1)).is_some_and(is_utf8)
+                    || encoded.get(i..i.wrapping_add(2)).is_some_and(is_utf8)
+                    || encoded.get(i..i.wrapping_add(3)).is_some_and(is_utf8)
+                    || encoded.get(i..i.wrapping_add(4)).is_some_and(is_utf8)
+                    || encoded.get(i.wrapping_sub(1)..i).is_some_and(is_utf8)
+                    || encoded.get(i.wrapping_sub(2)..i).is_some_and(is_utf8)
+                    || encoded.get(i.wrapping_sub(3)..i).is_some_and(is_utf8)
+                    || encoded.get(i.wrapping_sub(4)..i).is_some_and(is_utf8)
+            );
+        }
+
+        let output = &encoded[range];
+        EnvStr::new(unsafe { OsStr::from_encoded_bytes_unchecked(output) })
     }
 }
 
 impl AsRef<OsStr> for EnvStr {
     fn as_ref(&self) -> &OsStr {
-        self.0.as_ref()
+        &self.0
     }
 }
 
 impl Default for &EnvStr {
     fn default() -> Self {
-        EnvStr::new("")
+        EnvStr::new(OsStr::new(""))
     }
+}
+
+pub(crate) enum EnvChar {
+    Valid(char),
+    Invalid,
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,12 +2,12 @@ use crate::{
     Color, CrateType, Emit, ErrorFormat, Flag, LibraryKind, LinkKind, LinkModifier,
     LinkModifierPrefix, LintLevel,
 };
-use std::ffi::OsString;
+use std::ffi::{OsStr, OsString};
 use std::path::PathBuf;
 
 #[track_caller]
 fn test(encoded: &str, expected: &[Flag]) {
-    let mut iterator = crate::from_encoded(encoded);
+    let mut iterator = crate::from_encoded(OsStr::new(encoded));
 
     let mut flags = Vec::new();
     for expected in expected {
@@ -20,7 +20,8 @@ fn test(encoded: &str, expected: &[Flag]) {
 
     assert_eq!(None, iterator.next());
 
-    let mut iterator = crate::from_encoded(&flags.join("\x1F"));
+    let re_encoded = flags.join("\x1F");
+    let mut iterator = crate::from_encoded(OsStr::new(&re_encoded));
 
     for expected in expected {
         assert_eq!(Some(expected), iterator.next().as_ref());


### PR DESCRIPTION
In the arguments of flags such as `--extern` and `--sysroot` and `-L` and `-o` and `--out-dir` and `--extern-location` and `--remap-path-prefix`.